### PR TITLE
Feature/div2 api service

### DIFF
--- a/SRC/FOO/FOO.CPP
+++ b/SRC/FOO/FOO.CPP
@@ -7,6 +7,7 @@
 
 #include <assert.h>
 #include "..\H\FOO.H"
+#include "..\H\DIV2.H"
 
 const int TLSA_ENGINE_MAJOR_VERSION = 0;
 const int TLSA_ENGINE_MINOR_VERSION = 1;

--- a/SRC/FOO/FOO.CPP
+++ b/SRC/FOO/FOO.CPP
@@ -37,7 +37,7 @@ void registerFooService()
 {
     service.getHelloWorldMessage = getHelloWorldMessage;
 
-    int result = SERVICES->registerService(FOO_SERVICE, &service);
+    int result = engine->services->registerService(FOO_SERVICE, &service);
 
     assert(result == RESULT_OK);
 }
@@ -53,6 +53,7 @@ void __export divmain(COMMON_PARAMS)
     // abstracted by a shared service from SYSTEM.DLL (this call should be executed one time 
     // and only by SYSTEM.DLL).
     GLOBAL_IMPORT();
+    engine = (tlsa98_engine_t *)TLSA98_ENGINE_ADDRESS;
 
     // TODO: Implement own assert to allow custom assertion messages, outputs like the future 
     // built-in game console or error reporter, and termination action (end program or 

--- a/SRC/H/DIV2.H
+++ b/SRC/H/DIV2.H
@@ -1,19 +1,19 @@
 
-// ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
-// DIV Games Studio - Dinamic Link Library - Header File (c) 1998 HAMMER Tech.
-// ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
+//! DIV Games Studio 2 - Dinamic Link Library - Header File.
+//! @copyright DIV Games Studio 2 (C) Hammer Technologies, Daniel Navarro Medrano - 1998, 1999
+//! @copyright TLSA98 Engine (C) VisualStudioEX3, Jos‚ Miguel S nchez Fern ndez - 2022, 2023
+/*!
+    Modified DIV Games Studio 2 API header for TLSA98 Engine.
+*/
 
 #ifndef __DIV_H_
 #define __DIV_H_
 
 #include <stdio.h>
 
-#ifdef GLOBALS
-  #define EXTERN
-  void main(){};
-#else
-  #define EXTERN extern
-#endif
+void main()
+{
+}
 
 // ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
 // Common definitions for all libraries
@@ -288,46 +288,44 @@ void ss_end(void);                          // Screen Saver ending function
 // DIV exported variables - Internal - You must use above definitions!
 // ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
 
-EXTERN int  *_stack;
-EXTERN int  *_mem;
-EXTERN char *_palette;
-EXTERN char *_active_palette;
-EXTERN char *_key;
-
-EXTERN int  *_sp;
-EXTERN int  *_wide;
-EXTERN int  *_height;
-EXTERN int  *_ss_time;
-EXTERN int  *_ss_status;
-EXTERN int  *_ss_exit;
-EXTERN int  *_process_size;
-EXTERN int  *_id_offset;
-EXTERN int  *_id_init_offset;
-EXTERN int  *_id_start_offset;
-EXTERN int  *_id_end_offset;
-EXTERN int  *_set_palette;
-
-EXTERN unsigned long _buffer;
-EXTERN unsigned long _background;
-EXTERN unsigned long _ghost;
+int  *_stack;
+int  *_mem;
+char *_palette;
+char *_active_palette;
+char *_key;
+int  *_sp;
+int  *_wide;
+int  *_height;
+int  *_ss_time;
+int  *_ss_status;
+int  *_ss_exit;
+int  *_process_size;
+int  *_id_offset;
+int  *_id_init_offset;
+int  *_id_start_offset;
+int  *_id_end_offset;
+int  *_set_palette;
+unsigned long _buffer;
+unsigned long _background;
+unsigned long _ghost;
 
 // ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
 // DIV exported functions
 // ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
 
-EXTERN void *(*div_malloc)(size_t __size);             // Don't use malloc()!!!
-EXTERN void  (*div_free  )( void *__ptr );             // Don't use free()!!!
-EXTERN FILE *(*div_fopen )(char *,char *);             // Don't use fopen()!!!
-EXTERN void  (*div_fclose)(FILE *);                    // Don't use fclose()!!!
-
-EXTERN int   (*div_rand)(int rang_low,int rang_hi);    // Random between two numbers
-EXTERN void  (*div_text_out)(char *texto,int x,int y); // Screen print function
+void *(*div_malloc)(size_t __size);             // Don't use malloc()!!!
+void  (*div_free  )( void *__ptr );             // Don't use free()!!!
+FILE *(*div_fopen )(char *,char *);             // Don't use fopen()!!!
+void  (*div_fclose)(FILE *);                    // Don't use fclose()!!!
+int   (*div_rand)(int rang_low,int rang_hi);    // Random between two numbers
+void  (*div_text_out)(char *texto,int x,int y); // Screen print function
 
 // ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
 // Macros to get parameters and return values in new functions
 // ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
 
-#define getparm()     stack[sp--]           // Get next parameter
+#define getparm()     stack[sp--]           // Get next parameter as integer
+#define getstrparm()  (char *)(&mem[text_offset + getparm()]) // Get next parameter as string
 #define retval(_x_sp) (stack[++sp]=(_x_sp)) // Set return value (is a must)
 
 // ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
@@ -370,6 +368,12 @@ EXTERN void  (*div_text_out)(char *texto,int x,int y); // Screen print function
 #define DIRINFO     ((_dirinfo     *)&mem[long_header+14+10*10+10*7+8+11+9+10*4])
 #define FILEINFO    ((_fileinfo    *)&mem[long_header+14+10*10+10*7+8+11+9+10*4+1026])
 #define VIDEO_MODES ((_video_modes *)&mem[long_header+14+10*10+10*7+8+11+9+10*4+1026+146])
+
+// ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
+// Definition to get the TLSA98 Engine address in DIV's memory
+// ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
+
+#define TLSA98_ENGINE_ADDRESS (void *)NET
 
 // ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
 // Definition to get the offset of objects

--- a/SRC/H/SYSTEM/DIV2API.H
+++ b/SRC/H/SYSTEM/DIV2API.H
@@ -1,0 +1,55 @@
+//! SYSTEM.DLL - System library for DIV Games Studio 2.
+//! @copyright TLSA98 Engine (C) VisualStudioEX3, José Miguel Sánchez Fernández - 2022, 2023
+//! @copyright DIV Games Studio 2 (C) Hammer Technologies, Daniel Navarro Medrano - 1998, 1999
+/*!
+    DIV Games Studio 2 API abstraction.
+*/
+
+#ifndef __SYSTEM_DLL_DIV2_API_H_
+#define __SYSTEM_DLL_DIV2_API_H_
+
+#include <stdio.h>
+
+typedef void *(*div2_malloc_f)(size_t);
+typedef void (*div2_free_f)(void *);
+
+/// @brief DIV Games Studio 2 memory functions and members.
+typedef struct
+{
+    /// @brief Access to DIV Games Studio 2 session memory (the mem[] array).
+    int *session;
+
+    /// @brief DIV version of malloc.
+    div2_malloc_f _malloc;
+
+    /// @brief DIV version of free.
+    div2_free_f _free;
+} div2_api_memory_t;
+
+typedef FILE *(*div2_fopen_f)(char *, char *);
+typedef void (*div2_fclose_f)(FILE *);
+
+/// @brief DIV Games Studio 2 file system functions and members.
+typedef struct
+{
+    /// @brief DIV version of fopen.
+    div2_fopen_f _fopen;
+
+    /// @brief DIV version of fclose.
+    div2_fclose_f _fclose;
+} div2_api_file_system_t;
+
+/// @brief DIV Games Studio 2 API abstraction.
+/// @remarks This implementation not only ease use the DIV2.H code, is also a way to avoid
+/// the linker warning 1027 issue with some parts of DIV2.H that always are redefined when you
+/// include the header in several files.
+typedef struct
+{
+    /// @brief DIV Games Studio 2 memory functions and members.
+    div2_api_memory_t *memory;
+
+    /// @brief DIV Games Studio 2 file system functions and members.
+    div2_api_file_system_t *fileSystem;
+} div2_api_t;
+
+#endif

--- a/SRC/H/SYSTEM/GLOBALS.H
+++ b/SRC/H/SYSTEM/GLOBALS.H
@@ -8,12 +8,11 @@
 #ifndef __SYSTEM_DLL_GLOBALS_H_
 #define __SYSTEM_DLL_GLOBALS_H_
 
-#define GLOBALS        // Requires by DIV.H before include it.
 #define DOSBOX_SUPPORT // Uncomment this for support and fixes for DOSBox emulator.
 
 #include <stdarg.h> // Required for va_copy macro.
 #include <string.h> // Required for va_copy macro.
-#include "..\DIV.H" // DIV Games Studio 2 API.
+#include "..\DIV2.H" // DIV Games Studio 2 API.
 
 /// @brief True constant value.
 /// @remarks In DIV Games Studio, all odd values are considered as true value.
@@ -174,24 +173,10 @@ typedef struct
 /// but not initialized until the game code tries to initialize the network system. This
 /// allow us to use this memory to store the pointer to the main eneigne interface, and be
 /// accessible for all DLLs that uses the SYSTEM.H header file.
-#define ENGINE ((const tlsa98_engine_t *)NET)
-
-/// @brief Gets the signature of the TLSA98 Engine runtime instance.
-/// @remarks Use with TLSA98_ENGINE_SIGNATURE definition to check if the ENGINE access is
-/// properly initialized.
-#define SIGNATURE (ENGINE->signature)
-
-/// @brief Gets the version of the TLSA98 Engine runtime instance.
-/// @remarks Use TLSA98_ENGINE_VERSION_MAJOR and TLSA98_ENGINE_VERSION_MINOR to check API
-/// compatibility. TLSA98_ENGINE_VERSION_BUILD and TLSA98_ENGINE_VERSION_REVISION should not
-/// be taking in count when you check the API compatibility.
-#define VERSION ((const version_t *)ENGINE->version)
-
-/// @brief Access to TLSA98 Engine services.
-#define SERVICES ((const service_provider_t *)ENGINE->services)
+tlsa98_engine_t *engine;
 
 /// @brief Returns true if engine instance signature matches with header definition signature.
-#define TLSA98_ENGINE_SIGNATURE_EQUALS (SIGNATURE == TLSA98_ENGINE_SIGNATURE)
+#define TLSA98_ENGINE_SIGNATURE_EQUALS (engine->signature == TLSA98_ENGINE_SIGNATURE)
 
 /// @brief Checks if engine instance major and minor version are major or equal than
 /// major and minor parameters.
@@ -200,7 +185,7 @@ typedef struct
 /// @return Returns true if engine instance major and minor version are major or equal than
 /// requiured _major and _minor parameters, false otherwise.
 #define TLSA98_ENGINE_VERSION_MAJOR_OR_EQUALS(_major, _minor) \
-    VERSION->major >= _major && VERSION->minor >= _minor
+    engine->version->major >= _major && engine->version->minor >= _minor
 
 /// @brief Gets the size of an array.
 /// @param a Array to measure.
@@ -209,10 +194,6 @@ typedef struct
 
 /// @brief Custom implemnetation of ANSI C99 va_copy macro.
 #define va_copy(dst, src) memcpy((void *)dst, (void *)src, sizeof(va_list));
-
-/// @brief #DIV::getparm() version to get a DIV Games Studio 2 STRING parameters.
-/// @return Returns the next parameter from DIV function stack as string value.
-#define getstrparm() (string)(&mem[text_offset + getparm()])
 
 /// @brief malloc() alias to DIV implementation.
 /// @param size Size of the memory region to allocate.
@@ -254,6 +235,6 @@ typedef struct
 /// @param id The service id.
 /// @return Returns the pointer to the service, #DIV::NULL if the id is not found.
 /// @remarks Shortcut to ENGINE->services->getService function.
-#define getService(id) SERVICES->getService(id)
+#define getService(id) engine->services->getService(id)
 
 #endif

--- a/SRC/H/SYSTEM/GLOBALS.H
+++ b/SRC/H/SYSTEM/GLOBALS.H
@@ -12,7 +12,10 @@
 
 #include <stdarg.h> // Required for va_copy macro.
 #include <string.h> // Required for va_copy macro.
-#include "..\DIV2.H" // DIV Games Studio 2 API.
+#include "..\SYSTEM\DIV2API.H"
+
+/// @brief NULL constant value.
+#define NULL 0
 
 /// @brief True constant value.
 /// @remarks In DIV Games Studio, all odd values are considered as true value.
@@ -146,16 +149,20 @@ typedef struct
     /// @remarks Use it to check if the pointer address this interface and avoid errors
     /// if the engine is not properly initialized.
     int signature;
+    
     /// @brief Engine version.
     /// @remarks Identifies the engine version. Use it to ensure if your code is
     /// compatible with the engine version.
     version_t *version;
+    
+    /// @brief DIV Games Studio 2 API abstraction.
+    div2_api_t *div2API;
+    
     /// @brief Engine services provider.
     service_provider_t *services;
+
     /// @brief Reserved for future implementations.
-    void *reserved1;
-    /// @brief Reserved for future implementations.
-    void *reserved2;
+    void *reserved;
 } tlsa98_engine_t;
 
 /// @brief Gets the TLSA98 Engine runtime instance.
@@ -202,7 +209,7 @@ tlsa98_engine_t *engine;
 /// memory allocations. If you try to use the standard malloc() the program starts to generate
 /// memory corruption and even crashes. This macro allows you to use safe malloc() calls but
 /// using the DIV implementation.
-#define malloc(size) div_malloc(size)
+#define malloc(size) engine->div2API->memory->_malloc(size)
 
 /// @brief free() alias to DIV implementation.
 /// @param ptr Pointer of the memory region to release.
@@ -210,7 +217,7 @@ tlsa98_engine_t *engine;
 /// memory deallocations. If you try to use the standard free() the program starts to generate
 /// memory corruption and even crashes. This macro allows you to use safe free() calls but
 /// using the DIV implementation.
-#define free(ptr) div_free(ptr)
+#define free(ptr) engine->div2API->memory->_free(ptr)
 
 /// @brief fopen() alias to DIV implementation.
 /// @param filename The path and name of the file to open.
@@ -221,7 +228,7 @@ tlsa98_engine_t *engine;
 /// file open operations. If you try to use the standard fopen() the program starts to
 /// generate memory corruption and even crashes. This macro allows you to use safe fopen()
 /// calls but using the DIV implementation.
-#define fopen(filename, mode) div_fopen(filename, mode)
+#define fopen(filename, mode) engine->div2API->fileSystem->_fopen(filename, mode)
 
 /// @brief fclose() alias to DIV implementation.
 /// @param file The pointer to file to close.
@@ -229,7 +236,7 @@ tlsa98_engine_t *engine;
 /// file close operations. If you try to use the standard fclose() the program starts to
 /// generate memory corruption and even crashes. This macro allows you to use safe fclose()
 /// calls but using the DIV implementation.
-#define fclose(file) div_fclose(file)
+#define fclose(file) engine->div2API->fileSystem->_fclose(file)
 
 /// @brief Finds and gets the service instance from the engine service provider.
 /// @param id The service id.

--- a/SRC/SYSTEM/SERVICES.CPP
+++ b/SRC/SYSTEM/SERVICES.CPP
@@ -64,8 +64,6 @@ void initializeServiceProvider()
     // Create and initialize the service container:
     serviceContainer = createList(MAX_SERVICES, sizeof(service_t));
 
-    tlsa98_engine_t *engine = (tlsa98_engine_t *)NET;
-
     // Create and initialize the service provider:
     engine->services = (service_provider_t *)malloc(sizeof(service_provider_t));
     {

--- a/SRC/SYSTEM/SYSTEM.CPP
+++ b/SRC/SYSTEM/SYSTEM.CPP
@@ -10,8 +10,6 @@
 
 static void initializeEngineInterface()
 {
-    tlsa98_engine_t *engine = (tlsa98_engine_t *)NET;
-
     memset(engine, NULL, sizeof(tlsa98_engine_t));
 
     engine->signature = TLSA98_ENGINE_SIGNATURE;
@@ -39,6 +37,7 @@ static void initializeDIVCallbacks()
 void __export divmain(COMMON_PARAMS)
 {
     GLOBAL_IMPORT();
+    engine = (tlsa98_engine_t *)TLSA98_ENGINE_ADDRESS;
 
     initializeEngineInterface();
     initializeServices();

--- a/SRC/SYSTEM/SYSTEM.CPP
+++ b/SRC/SYSTEM/SYSTEM.CPP
@@ -7,13 +7,38 @@
 
 #include "..\H\SYSTEM.H"
 #include "..\H\SYSTEM\SERVICES.H"
+#include "..\H\DIV2.H"
+
+static void initializeDIV2APIService()
+{
+    engine->div2API = (div2_api_t *)div_malloc(sizeof(div2_api_t));
+
+    div2_api_t *div2 = engine->div2API;
+
+    div2->memory = (div2_api_memory_t *)div_malloc(sizeof(div2_api_memory_t));
+
+    div2_api_memory_t *memory = div2->memory;
+    {
+        memory->session = mem;
+        memory->_malloc = div_malloc;
+        memory->_free = div_free;
+    }
+
+    div2->fileSystem = (div2_api_file_system_t *)malloc(sizeof(div2_api_file_system_t));
+
+    div2_api_file_system_t *fileSystem = div2->fileSystem;
+    {
+        fileSystem->_fopen = div_fopen;
+        fileSystem->_fclose = div_fclose;
+    }
+}
 
 static void initializeEngineInterface()
 {
     memset(engine, NULL, sizeof(tlsa98_engine_t));
 
     engine->signature = TLSA98_ENGINE_SIGNATURE;
-    engine->version = (version_t *)malloc(sizeof(version_t));
+    engine->version = (version_t *)div_malloc(sizeof(version_t));
     {
         version_t *version = engine->version;
 
@@ -23,6 +48,7 @@ static void initializeEngineInterface()
         version->revision = TLSA98_ENGINE_VERSION_REVISION;
     }
 
+    initializeDIV2APIService();
     initializeServiceProvider();
 }
 


### PR DESCRIPTION
Finished abstraction of DIV2 API service. This feature several reduced the linking warning 1027 avoiding include DIV2.H header in several files (now only is included in main DLL file).